### PR TITLE
Fixed Webpack API_URL issue

### DIFF
--- a/src/FileUploadWidget.js
+++ b/src/FileUploadWidget.js
@@ -15,7 +15,7 @@ import uuid from 'uuid';
 
 const endpoint = process.env.API_URL;
 
-class FileUpload extends Component {
+class FileUploadWidget extends Component {
   constructor(props) {
     super(props);
       const uniqueid = crypto.createHmac('sha256', uuid.v4()).digest('hex');
@@ -242,4 +242,4 @@ class FileUpload extends Component {
   }
 }
 
-export default FileUpload;
+export default FileUploadWidget;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 var path = require('path');
+const webpack = require('webpack');
+
 module.exports = {
   entry: './src/index.js',
   output: {
@@ -28,4 +30,12 @@ module.exports = {
   externals: {
     react: 'commonjs react',
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+        API_URL: JSON.stringify(process.env.API_URL || "https://localhost:5000")
+      },
+    })
+  ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: path.resolve(__dirname, 'src'),
-        exclude: /(node_modules|bower_components|build)/,
+        exclude: /(node_modules|bower_components)/,
         use: {
           loader: 'babel-loader',
           options: {


### PR DESCRIPTION
Webpack needs to set up the API_URL env var for the rest of the components, FileUploadWidget needs this URL to have each file signed by s3 through the backend and uploaded to s3 directly. Also, renamed the Class code in FileUploadWidget.js to match its component file name.